### PR TITLE
✨ feat: itinerary-front

### DIFF
--- a/src/main/resources/static/css/edit.css
+++ b/src/main/resources/static/css/edit.css
@@ -373,7 +373,7 @@
 }
 
 .event-place-type{
-    font-size:0.8em;
+    font-size:0.76em;
 }
 
 .event-under-content{
@@ -381,9 +381,45 @@
     gap: 5px;
 }
 
-.event-time{
-    font-size:0.8em;
+.event-time-wrap{
+    display:flex;
+    align-items: center;
+    justify-content: center;
 }
+
+.event-time-wrap .event-time{
+    font-size:0.76em;
+    margin-right: 5px;
+}
+
+.event-time-wrap .warning-icon {
+    display: none;
+    color: #ed0000;
+    vertical-align: middle;
+    font-size: 0.60em;
+}
+
+.event-time-wrap.warn .warning-icon {
+    display: block;
+}
+
+.event-time-wrap.warn .event-time{
+    color: #ed0000 !important;
+}
+
+
+
+.event-time-wrap .opening-hours-warning{
+    display:none;
+    font-size: 0.6em;
+    font-weight: 500;
+    color: #ed0000;
+}
+
+.event-time-wrap.warn .opening-hours-warning{
+    display:block !important;
+}
+
 
 .event-left {
     padding-left: 5px;
@@ -404,7 +440,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-right: 3px;
+    padding: 5px;
 }
 
 .event-remove.place-btn {
@@ -413,7 +449,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-right: 10px;
+    margin-right: 3px;
+    padding: 5px;
 }
 
 


### PR DESCRIPTION
머무는 시간 인풋박스 더블클릭 시 이벤트 전파 중지 처리
영업시간 초과 시 경고 표시 출력
쓰레기통 영역 그랩 제한 처리
복제 버튼, 쓰레기통 그랩 제한되도록 패딩 추가
장소가 없을 경우 itinerary edit 진입 시 기본 지역(1번)으로 이동 및 지역 지도 초기화 (※ view는 아직 적용 전)
첫 번째 장소가 숙소일 경우 stayTime을 0으로 초기화 (단, 이번 edit 세션에서 stayTime을 수정한 경우는 제외)
장소 이동 시 아이콘 사라지는 버그 수정